### PR TITLE
Switch from exec() to invoke() for Seurat calls

### DIFF
--- a/R/CiteSeq.R
+++ b/R/CiteSeq.R
@@ -102,7 +102,7 @@ AppendCiteSeq <- function(seuratObj, unfilteredMatrixDir, normalizeMethod = 'dsb
 		if (is.null(replacementAssay)) {
 			args <- list()
 			args[[slot]] <- slotData
-			replacementAssay <- rlang:::exec(Seurat::CreateAssayObject, !!!args)
+			replacementAssay <- rlang::invoke(Seurat::CreateAssayObject, args)
 		} else {
 			replacementAssay <- SetAssayData(replacementAssay, slot = slot, slotData)
 		}
@@ -166,7 +166,7 @@ AppendCiteSeq <- function(seuratObj, unfilteredMatrixDir, normalizeMethod = 'dsb
 		if (is.null(replacementAssay)) {
 			args <- list()
 			args[[slot]] <- slotData
-			replacementAssay <- rlang:::exec(Seurat::CreateAssayObject, !!!args)
+			replacementAssay <- rlang::invoke(Seurat::CreateAssayObject, args)
 		} else {
 			replacementAssay <- SetAssayData(replacementAssay, slot = slot, slotData)
 		}
@@ -202,7 +202,7 @@ AppendCiteSeq <- function(seuratObj, unfilteredMatrixDir, normalizeMethod = 'dsb
 		if (is.null(replacementAssay)) {
 			args <- list()
 			args[[slot]] <- Seurat::as.sparse(existingData)
-			replacementAssay <- rlang:::exec(Seurat::CreateAssayObject, !!!args)
+			replacementAssay <- rlang::invoke(Seurat::CreateAssayObject, args)
 		} else {
 			replacementAssay <- SetAssayData(replacementAssay, slot = slot, Seurat::as.sparse(existingData))
 		}

--- a/R/Seurat_III.R
+++ b/R/Seurat_III.R
@@ -231,7 +231,7 @@ NormalizeAndScale <- function(seuratObj, nVariableFeatures = NULL, block.size = 
     toBind[['object']] <- seuratObj
 
 	# To avoid 'reached iteration limit' warnings
-	seuratObj <- suppressWarnings(rlang:::exec(SCTransform, !!!toBind))
+	seuratObj <- suppressWarnings(rlang::invoke(SCTransform, toBind))
     seuratObj <- .ClearSeuratCommands(seuratObj)
 
 	return(seuratObj)
@@ -254,7 +254,7 @@ NormalizeAndScale <- function(seuratObj, nVariableFeatures = NULL, block.size = 
 	toBind[['verbose']] <- FALSE
     toBind[['object']] <- seuratObj
 
-	seuratObj <- rlang:::exec(FindVariableFeatures, !!!toBind)
+	seuratObj <- rlang::invoke(FindVariableFeatures, toBind)
     seuratObj <- .ClearSeuratCommands(seuratObj)
 
 	if (!all(is.null(variableGenesWhitelist))) {
@@ -576,7 +576,7 @@ FindClustersAndDimRedux <- function(seuratObj, dimsToUse = NULL, minDimsToUse = 
     }
   }
 
-  seuratObj <- rlang:::exec(RunUMAP, !!!umapArgs)
+  seuratObj <- rlang::invoke(RunUMAP, umapArgs)
   seuratObj <- .ClearSeuratCommands(seuratObj)
 
   for (reduction in c('tsne', 'umap')){


### PR DESCRIPTION
Switch from exec() to invoke() for Seurat calls, since the former still results in the serialized object being stored in the commands slot