### PR TITLE
support faceting in DotPlot code

### DIFF
--- a/R/Analysis.R
+++ b/R/Analysis.R
@@ -165,6 +165,7 @@ ConstructEnrichmentDataFrameAndDoStatistics <- function(seuratObj,
 #' @param maxSizeFactor The maximum allowable SizeFactor before an error is automatically thrown. For instance, a size factor of 100 means you have a group of 8000 cells that you're comparing to 80 cells. 
 #' @param independentVariableTestField This and dependentVariableTestField automatically define a small statistical test to see if your size factors are correlated. Ideally, they should not be if independentVariableTestField is not the same value as normalizationField. 
 #' @param dependentVariableTestField This value should be equal to sizeFactorField initially, but can be changed to interactively see other correlations in the metadata.
+#' @param facetingField The column name of the seruat object metadata that the end DotPlot should be facet_wrap'd by.
 #' @export
 MakeEnrichmentDotPlot <- function(seuratObj,
                                   yField = 'ClusterNames_0.2',
@@ -176,7 +177,8 @@ MakeEnrichmentDotPlot <- function(seuratObj,
                                   sizeFactorField = 'SizeFactor',
                                   maxSizeFactor = 100,
                                   independentVariableTestField = colorField,
-                                  dependentVariableTestField = sizeFactorField
+                                  dependentVariableTestField = sizeFactorField, 
+                                  facetingField = NULL
 
 ){
   
@@ -224,5 +226,13 @@ MakeEnrichmentDotPlot <- function(seuratObj,
     ylab(yField) +
     guides(fill = guide_colorbar(order = 1))
   
+  if(!is.null(facetingField)){
+    if(!(facetingField %in% extraGroupingFields)){
+      stop("Please add your desired facetingField to the extraGroupingFields variable.")
+    }
+    P1 <- P1 + 
+      facet_wrap(as.formula(paste("~", facetingField)), scales = "free_x")
+  }
+    
   return(P1)
 }

--- a/man/MakeEnrichmentDotPlot.Rd
+++ b/man/MakeEnrichmentDotPlot.Rd
@@ -15,7 +15,8 @@ MakeEnrichmentDotPlot(
   sizeFactorField = "SizeFactor",
   maxSizeFactor = 100,
   independentVariableTestField = colorField,
-  dependentVariableTestField = sizeFactorField
+  dependentVariableTestField = sizeFactorField,
+  facetingField = NULL
 )
 }
 \arguments{
@@ -40,6 +41,8 @@ MakeEnrichmentDotPlot(
 \item{independentVariableTestField}{This and dependentVariableTestField automatically define a small statistical test to see if your size factors are correlated. Ideally, they should not be if independentVariableTestField is not the same value as normalizationField.}
 
 \item{dependentVariableTestField}{This value should be equal to sizeFactorField initially, but can be changed to interactively see other correlations in the metadata.}
+
+\item{facetingField}{The column name of the seruat object metadata that the end DotPlot should be facet_wrap'd by.}
 }
 \description{
 An extremely overloaded function that calculates statistics and enrichment in Seurat Objects. Please see an example dot plot before using this function. Note the aggregated data can be obtained from the ggplot object (i.e. P1$data)


### PR DESCRIPTION
Hi all, 

This would allow for a faceting variable to be passed to the DotPlot code. 

I could improve it by automatically adding the `facetingField` to the vector of `extraGroupingFields` upstream of  `ConstructEnrichmentDataFrameAndDoStatistics()` but that could have some unintended grouping effects. 

Let me know what you think!