### PR TITLE
label differential expression list using contrast names

### DIFF
--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -197,6 +197,7 @@ PerformDifferentialExpression <- function(fit, contrast, contrast_name, logFC_th
 #' @return A list with the differential_expression results, volano ggplot object and pvalue_dist ggplot object
 #' @export
 RunPairwiseContrasts <- function(fit, test.use){
+  #create a nx2 array of all possible unique pairwise combinations of contrasts
   contrasts <- t(utils::combn(colnames(fit$design), m = 2))
   results <- future.apply::future_lapply(split(contrasts, 1:nrow(contrasts)) , FUN = function(x){
     up_contrast<- x[[1]]
@@ -206,6 +207,8 @@ RunPairwiseContrasts <- function(fit, test.use){
     contrast <- limma::makeContrasts(contrasts = contrast_name, levels = fit$design)
     result <- PerformDifferentialExpression(fit, contrast, contrast_name, logFC_threshold = 1, FDR_threshold = 0.05, test.use = test.use)
   })
-
+  #use contrast names to label the results list
+  names(results) <- paste(contrasts[,1],  "-", contrasts[,2])
   return(results)
+}
 }

--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -208,6 +208,6 @@ RunPairwiseContrasts <- function(fit, test.use){
     result <- PerformDifferentialExpression(fit, contrast, contrast_name, logFC_threshold = 1, FDR_threshold = 0.05, test.use = test.use)
   })
   #use contrast names to label the results list
-  names(results) <- paste(contrasts[,1],  "-", contrasts[,2])
+  names(results) <- paste0(contrasts[,1],  "-", contrasts[,2])
   return(results)
 }

--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -211,4 +211,3 @@ RunPairwiseContrasts <- function(fit, test.use){
   names(results) <- paste(contrasts[,1],  "-", contrasts[,2])
   return(results)
 }
-}


### PR DESCRIPTION
This is a small change, it just changes the names in the differential expression list to match the name of the contrasts. 

Previously, the list was labeled by the index (e.g. 1,2,3...n for n contrasts) and now is labeled by the contrast names like in this image: 
<img width="555" alt="Screen Shot 2023-01-06 at 4 42 17 PM" src="https://user-images.githubusercontent.com/7402210/211122808-23fe340d-d448-40d5-af10-85aef00f584c.png">
