### PR TITLE
decrement escape version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,7 +83,7 @@ Imports:
     geometry,
     CSCORE,
     WGCNA,
-    escape (>= 1.99.1),
+    escape (>= 1.99.0),
     GSVA (>= 1.51.5),
     dynamicTreeCut
 Suggests:


### PR DESCRIPTION
Escape decremented their github version from 1.99.1 to 1.99.0. 

https://github.com/ncborcherding/escape/commit/6d15498de8000d8ff29c76253b0f001e2c241849#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cR3