### PR TITLE
Improve error handling around no DEGs in bar plot

### DIFF
--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -740,6 +740,7 @@ PseudobulkingBarPlot <- function(filteredContrastsResults, metadataFilterList = 
   #tag the genes as either up or down regulated
   filteredContrastsResults <- .addRegulationInformationAndFilterDEGs(filteredContrastsResults, logFC_threshold = logFC_threshold, FDR_threshold = FDR_threshold)
   
+  #check for DEGs. If there are none, raise an error. 
   if (all(unique(filteredContrastsResults$n_DEG %in% c(0)))) {
     stop("All of the genes in all of the contrasts failed to pass the FDR and logFC thresholds. You can consider adjusting the logFC_threshold and FDR_threshold arguments, but this is a reasonable result (i.e. no DEGs) when you are comparing very similar samples.")
   }

--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -740,6 +740,10 @@ PseudobulkingBarPlot <- function(filteredContrastsResults, metadataFilterList = 
   #tag the genes as either up or down regulated
   filteredContrastsResults <- .addRegulationInformationAndFilterDEGs(filteredContrastsResults, logFC_threshold = logFC_threshold, FDR_threshold = FDR_threshold)
   
+  if (all(unique(filteredContrastsResults$n_DEG %in% c(0)))) {
+    stop("All of the genes in all of the contrasts failed to pass the FDR and logFC thresholds. You can consider adjusting the logFC_threshold and FDR_threshold arguments, but this is a reasonable result (i.e. no DEGs) when you are comparing very similar samples.")
+  }
+  
   #Further filter contrasts associated with a list of vectors (metadataFilterList).
   if (!is.null(metadataFilterList)) {
     if (!is.list(metadataFilterList)) {


### PR DESCRIPTION
Hi all, 

This PR is in response to #251, which notes that `PseudobulkingBarPlot()` errors with an obscure ggplot faceting failure. The function now performs a basic check that there are any DEGs across the contrasts and errors with a more interpretable message. 

Impossible filter: 
``` 
PseudobulkingBarPlot(filteredContrasts = DE_results, metadataFilterList = NULL, logFC_threshold = 100, FDR_threshold = -1)
```

New error message: 
```
Error in PseudobulkingBarPlot(filteredContrasts = DE_results, metadataFilterList = NULL,  : 
  All of the genes in all of the contrasts failed to pass the FDR and logFC thresholds. You can consider adjusting the logFC_threshold and FDR_threshold arguments, but this is a reasonable result (i.e. no DEGs) when you are comparing very similar samples.
```