### PR TITLE
use more factor-friendly equivalance check in RunFilteredContrasts

### DIFF
--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -572,7 +572,7 @@ RunFilteredContrasts <- function(seuratObj, filteredContrastsFile = NULL, filter
     print(paste0("Contrast columns: ", attr(design,"contrast_columns")))
     for (contrast_column in attr(design, "contrast_columns")){
       #check if the contrast column in the parent Seurat object needs sanitizing before populating seuratObj.positive.contrast and seuratObj.negative.contrast downstream.
-      if (!all(seuratObj@meta.data[,contrast_column] == .RemoveSpecialCharacters(seuratObj@meta.data[,contrast_column]))) {
+      if (!all(identical(seuratObj@meta.data[,contrast_column], .RemoveSpecialCharacters(seuratObj@meta.data[,contrast_column])))) {
         print("Converting metadata columns to a make.names() format. Hyphens, spaces, underscores, and other non-alphanumeric characters will be converted to periods. Factor levels will be retained.")
         seuratObj@meta.data[,contrast_column] <- .RemoveSpecialCharacters(seuratObj@meta.data[,contrast_column])
       }


### PR DESCRIPTION
Hi all, 

This fixes some further woes with special characters in the pseudobulking pipeline. The prior equivalence check using `==` failed without yielding TRUE or FALSE here: https://github.com/bimberlabinternal/CellMembrane/blob/4b8e28db890b17944421eede0731d1bf83144096/R/PseudoBulk.R#L575 

this now uses `identical()` to dodge this issue regardless of factor levels and returns FALSE when the factor-vectors are not the same. 