### PR TITLE
Support for alphanumeric groupFields in TCR diversity calculation

### DIFF
--- a/R/CoNGA.R
+++ b/R/CoNGA.R
@@ -247,6 +247,9 @@ CalculateTcrDiversity <- function(inputData,
   df <- read.csv(outputFile)
 
   y <- colnames(df)[grepl("^Z", colnames(df)) & !grepl("_LCL_|_UCL_", colnames(df))]
+  if (is.null(y) || length(y) == 0) {
+    stop('Parsing error in tcrdist3 output. No columns containing diversity metrics were found.')
+  }
   print(df |> select(c("order", y)) |>
     tidyr::pivot_longer(cols = y, names_to = "sample_div", values_to = "y") |> 
     ggplot(aes(x = order, y = y)) + geom_line(aes(color = sample_div)) + egg::theme_article()

--- a/R/CoNGA.R
+++ b/R/CoNGA.R
@@ -246,7 +246,7 @@ CalculateTcrDiversity <- function(inputData,
   
   df <- read.csv(outputFile)
 
-  y <- grep("Z_[0-9]+", colnames(df), value = T)
+  y <- colnames(df)[grepl("^Z", colnames(df)) & !grepl("_LCL_|_UCL_", colnames(df))]
   print(df |> select(c("order", y)) |>
     tidyr::pivot_longer(cols = y, names_to = "sample_div", values_to = "y") |> 
     ggplot(aes(x = order, y = y)) + geom_line(aes(color = sample_div)) + egg::theme_article()


### PR DESCRIPTION
Hi everyone, 

This is a small change to allow alphanumeric columns to be groupFields for `CalculateTCRDiversity()`. I think the original point was to eliminate the upper and lower confidence interval columns in the data frame after `calculate_Diversity()`. This had the side effect of not allowing any alphanumeric field to be used, as they all got filtered by the `grep("Z_[0-9]+...)`.

This now removes all D_ columns and Z_UCL_ and  Z_LCL_ columns. 

Best regards, 
GW