### PR TITLE
Update ClusteredDotPlot default colors

### DIFF
--- a/R/Analysis.R
+++ b/R/Analysis.R
@@ -567,12 +567,13 @@ ClusteredDotPlot <- function(seuratObj, features, groupFields = "ClusterNames_0.
     as.matrix() |>
     Matrix::t()
   #Establish symmetric color scaling based on the extremes in the heatmap
-  col_RNA = circlize::colorRamp2(c(-max(abs(mat)), 0, max(abs(mat))),
-                                 c(grDevices::hcl.colors(palette = "Blue-Red 2", n = 20)[1],
-                                   "gray85",
-                                   grDevices::hcl.colors(palette = "Blue-Red 2", n = 20)[20]),
+  col_RNA = circlize::colorRamp2(quantile(c(-max(abs(mat)), 0, max(abs(mat)))),
+                                 c("#0000FFFF",
+                                   "#7F53FDFF",
+                                   "gray90",
+                                   "#FF6948FF",
+                                   "#FF0000FF"),
                                  space = "sRGB")
-  
   pct <- pct[,fullorder]
   
   #Set the heatmap name according to scaling

--- a/R/Analysis.R
+++ b/R/Analysis.R
@@ -568,11 +568,11 @@ ClusteredDotPlot <- function(seuratObj, features, groupFields = "ClusterNames_0.
     Matrix::t()
   #Establish symmetric color scaling based on the extremes in the heatmap
   col_RNA = circlize::colorRamp2(quantile(c(-max(abs(mat)), 0, max(abs(mat)))),
-                                 c("#0000FFFF",
-                                   "#7F53FDFF",
-                                   "gray90",
-                                   "#FF6948FF",
-                                   "#FF0000FF"),
+                                 c("#0000FFFF", #blue
+                                   "#7F53FDFF", #purple (pale)
+                                   "gray90", #very light gray
+                                   "#FF6948FF", #orangered/brick red
+                                   "#FF0000FF"), #red
                                  space = "sRGB")
   pct <- pct[,fullorder]
   


### PR DESCRIPTION
Hi everyone, 

Happy to spin this up into a more flexible solution for us to supply colors to the ClusteredDotPlots, but the default colors were a little washed out compared to the rather vibrant color bar. I swapped these to (I think) the defaults used by ComplexHeatmap. 

Before: 
![image](https://github.com/user-attachments/assets/96cd0bf8-79cd-43fa-8eac-49ebac701962)

After: 
![image](https://github.com/user-attachments/assets/113e5565-321f-4d9c-a3e8-38d51642c859)

Let me know if we prefer this merged quickly, or some scaffolding to allow for customization (e.g. passing a 'number of quantiles' argument for breaks + color vector). 

Best regards, 
GW
