### PR TITLE
Support filterByExpr in pseudobulking

### DIFF
--- a/R/PseudoBulk.R
+++ b/R/PseudoBulk.R
@@ -893,7 +893,7 @@ PseudobulkingBarPlot <- function(filteredContrastsResults, metadataFilterList = 
 #' @return A list containing the filtered dataframe used for plotting and the heatmap plot itself. 
 #' @export
 
-PseudobulkingDEHeatmap <- function(seuratObj, geneSpace = NULL, contrastField = NULL, negativeContrastValue = NULL, positiveContrastValue = NULL, subgroupingVariable = NULL, showRowNames = FALSE, assayName = "RNA", sampleIdCol = 'cDNA_ID', filterGenes = TRUE, subsetExpression = NULL) {
+PseudobulkingDEHeatmap <- function(seuratObj, geneSpace = NULL, contrastField = NULL, negativeContrastValue = NULL, positiveContrastValue = NULL, subgroupingVariable = NULL, showRowNames = FALSE, assayName = "RNA", sampleIdCol = 'cDNA_ID', filterGenes = FALSE, subsetExpression = NULL) {
   #sanity check arguments
   if (is.null(contrastField)) {
     stop("Please define a contrastField. This is a metadata variable (supplied to groupFields during PseudobulkSeurat()) that will be displayed on the top of the heatmap.")

--- a/man/PerformGlmFit.Rd
+++ b/man/PerformGlmFit.Rd
@@ -9,7 +9,7 @@ PerformGlmFit(
   design,
   test.use = "QLF",
   assayName = "RNA",
-  minCountsPerGene = 1,
+  filterGenes = TRUE,
   legacy = FALSE,
   plotBCV = TRUE
 )
@@ -23,7 +23,7 @@ PerformGlmFit(
 
 \item{assayName}{The name of the assay to use}
 
-\item{minCountsPerGene}{Any genes with fewer than this many counts (across samples) will be dropped.}
+\item{filterGenes}{A boolean controlling whether or not to filter genes using edgeR::filterByExpr. If TRUE, genes with low counts will be filtered out.}
 
 \item{legacy}{A passthrough variable for edgeR's glmQLF function. They recently (R 4.0) changed the default behavior, so this will break on earlier versions of R.}
 

--- a/man/PseudobulkingDEHeatmap.Rd
+++ b/man/PseudobulkingDEHeatmap.Rd
@@ -14,7 +14,7 @@ PseudobulkingDEHeatmap(
   showRowNames = FALSE,
   assayName = "RNA",
   sampleIdCol = "cDNA_ID",
-  filterGenes = TRUE,
+  filterGenes = FALSE,
   subsetExpression = NULL
 )
 }

--- a/man/PseudobulkingDEHeatmap.Rd
+++ b/man/PseudobulkingDEHeatmap.Rd
@@ -14,7 +14,7 @@ PseudobulkingDEHeatmap(
   showRowNames = FALSE,
   assayName = "RNA",
   sampleIdCol = "cDNA_ID",
-  minCountsPerGene = 1,
+  filterGenes = TRUE,
   subsetExpression = NULL
 )
 }
@@ -37,7 +37,7 @@ PseudobulkingDEHeatmap(
 
 \item{sampleIdCol}{The metadata column denoting the variable containing the sample identifier (for grouping).}
 
-\item{minCountsPerGene}{Passthrough variable for PerformGlmFit, used for filtering out lowly expressed genes.}
+\item{filterGenes}{A passthrough variable for PerformGlmFit, used to determine if genes should be filtered using edgeR::filterByExpr.}
 
 \item{subsetExpression}{An optional string containing an expression to subset the Seurat object. This is useful for selecting an exact subpopulation to in which to show DEGs. Please note that for string-based metadata fields, you will need to mix single and double quotes to ensure your expression is properly parsed. For instance, note the double quotes around the word unvax in this expression: subsetExpression = 'vaccine_cohort == "unvax"'.}
 }

--- a/man/RunFilteredContrasts.Rd
+++ b/man/RunFilteredContrasts.Rd
@@ -11,7 +11,7 @@ RunFilteredContrasts(
   design,
   test.use,
   logFC_threshold = 1,
-  minCountsPerGene = 1,
+  filterGenes = TRUE,
   FDR_threshold = 0.05,
   assayName = "RNA",
   showPlots = FALSE
@@ -30,7 +30,7 @@ RunFilteredContrasts(
 
 \item{logFC_threshold}{A passthrough argument specifying the log fold change threshold to be used by PerformDifferentialExpression (for plotting only).}
 
-\item{minCountsPerGene}{A passthrough argument specifying the minimum counts a gene must have before it is filtered and excluded from GLM fitting by PerformGlmFit().}
+\item{filterGenes}{A passthrough argument specifying whether or not PerformGlmFit should filter genes using edgeR::filterByExpr.}
 
 \item{FDR_threshold}{A passthrough argument specifying the FDR threshold to be used by PerformDifferentialExpression (for plotting only).}
 

--- a/tests/testthat/test-pseudobulk.R
+++ b/tests/testthat/test-pseudobulk.R
@@ -91,7 +91,7 @@ test_that("Logic gate study design works", {
                        test.use = "QLF", 
                        logFC_threshold = 0,
                        FDR_threshold = 0.5,
-                       minCountsPerGene = 1, 
+                       filterGenes = TRUE, 
                        assayName = "RNA")
   #15 total contrasts
   testthat::expect_equal(length(DE_results), expected = 15)

--- a/tests/testthat/test-pseudobulk.R
+++ b/tests/testthat/test-pseudobulk.R
@@ -43,6 +43,7 @@ test_that("Pseudobulk-based differential expression works", {
 })
 
 test_that("Logic gate study design works", {
+  CellMembrane::SetSeed(CellMembrane::GetSeed())
   seuratObj <- suppressWarnings(Seurat::UpdateSeuratObject(readRDS('../testdata/seuratOutput.rds')))
   testthat::expect_equal(ncol(seuratObj), expected = 1557) #check that test seuratObj doesn't change
   #add fabricated study metadata
@@ -96,12 +97,14 @@ test_that("Logic gate study design works", {
   #15 total contrasts
   testthat::expect_equal(length(DE_results), expected = 15)
   #9008 "DEGs" in the first contrast (note overly permissive DEG thresholds)
-  testthat::expect_equal(nrow(DE_results$`1`), expected = 9008)
+  testthat::expect_equal(nrow(DE_results$`1`), expected = 900)
   #test that pct.1 and pct.2 are present in the DE results
   testthat::expect_true(all(c("pct.1", "pct.2") %in%  colnames(DE_results$`1`)))
   
   barPlot <- PseudobulkingBarPlot(filteredContrasts = DE_results, 
-                       metadataFilterList = NULL
+                       metadataFilterList = NULL, 
+                       logFC_threshold = 0,
+                       FDR_threshold = 0.5
                        )
   #test that PseudobulkingBarPlot yields a list with a barPlot element
   testthat::expect_true("barPlot" %in% names(barPlot))
@@ -114,7 +117,8 @@ test_that("Logic gate study design works", {
                                          geneSpace = genes, 
                                          contrastField = "vaccine_cohort", 
                                          negativeContrastValue = "control", 
-                                         sampleIdCol = 'subject'
+                                         sampleIdCol = 'subject', 
+                                         filterGenes = FALSE
   )
   
   #test that PseudobulkingDEHeatmap yields a list with a heatmap and matrix element

--- a/vignettes/Pseudobulking-and-Filtered-Contrasts.Rmd
+++ b/vignettes/Pseudobulking-and-Filtered-Contrasts.Rmd
@@ -235,7 +235,7 @@ DE_results <- RunFilteredContrasts(seuratObj = pbulk,
                        test.use = "QLF", 
                        logFC_threshold = 1,
                        FDR_threshold = 0.05,
-                       minCountsPerGene = 1, 
+                       filterGenes = TRUE, 
                        assayName = "RNA")
 ```
 
@@ -252,7 +252,7 @@ permissive_contrast <- RunFilteredContrasts(seuratObj = pbulk,
                        test.use = "QLF", 
                        logFC_threshold = 0,
                        FDR_threshold = 0.5,
-                       minCountsPerGene = 1, 
+                       filterGenes = TRUE, 
                        assayName = "RNA", 
                        showPlots = TRUE)
 ```
@@ -266,7 +266,7 @@ strict_contrast <- RunFilteredContrasts(seuratObj = pbulk,
                        test.use = "QLF", 
                        logFC_threshold = 1,
                        FDR_threshold = 1e-30,
-                       minCountsPerGene = 1, 
+                       filterGenes = TRUE, 
                        assayName = "RNA", 
                        showPlots = TRUE)
 ```
@@ -289,11 +289,11 @@ barplot_results <- PseudobulkingBarPlot(DE_results,
                                         FDR_threshold = .5)
 ```
 
-```{r Create Strict Bar Plot}
+```{r Create Stricter Bar Plot}
 barplot_results <- PseudobulkingBarPlot(DE_results, 
                                         title = "Vaccine One vs Unvaxxed/Control", 
                                         logFC_threshold = 0.1, 
-                                        FDR_threshold = 0.1)
+                                        FDR_threshold = 0.5)
 ```
 
 Further annotation of the bar plot requires some custom code, but can be formatted like so using the data frame returned from `PseudobulkingBarPlot`: 
@@ -350,8 +350,8 @@ First, let's reuse the results of `FilterPseudobulkingContrasts` and apply some 
 ```{r filter DEGs for heatmap}
 #bind the list into a dataframe using thresholds to determine the differentially expressed genes
 DEGs <- dplyr::bind_rows(DE_results) %>% 
-  dplyr::filter(abs(logFC) > 1) %>% 
-  dplyr::filter(FDR < 0.05)
+  dplyr::filter(abs(logFC) > 0.5) %>% 
+  dplyr::filter(FDR < 0.4) #0.4 used only for this vignette. One should generally use 0.05 to be consistent with field standards
 
 #select all of the genes that are differentially expressed in any contrast across the transcriptome
 genes <- unique(DEGs$gene)


### PR DESCRIPTION
Hi all, 

@maanasa-kaza discussed results from a filtering function in edgeR (`filterByExpr()`)  this morning. 

This probably fits the bill for an out-of-the-box filtering step.  I'm pasting the arguments to the function and their defaults below. The one that will generally kill genes is `min.count = 10`. 

```
min.count: numeric. Minimum count required for at least some samples.

min.total.count: numeric. Minimum total count required across all samples.

large.n: integer. Number of samples per group that is considered to be “large”.

min.prop: numeric. In large sample situations, the minimum proportion of samples in a group that a gene needs to be expressed in. 
```

defaults: 
```
min.count = 10 
min.total.count = 15
large.n = 10
min.prop = 0.7
```

Previously, we simply filtered any gene with only 1 count across the experiment, which is the most permissive filter possible. Now, if the `filterGenes = TRUE` flag is toggled (default), then `filterByExpr()` will be triggered. Otherwise, one can pass `filterGenes = FALSE` and the pipeline's will revert to it's previous behavior (+ genes with 1 count). Buyer beware that rare genes/low abundance proteins (cytokines) can be hit by this. 

I am a little reluctant to add either of 1) four pass-through arguments to each function to support finer-grain filtering or 2) the ellipses construct for this.  The user always has the option to remove genes from the Seurat Object if they want finer control.  

Best regards, 
GW