### PR TITLE
Handle edge cases in robust errors

### DIFF
--- a/man/CalculateClusterEnrichmentPairwise.Rd
+++ b/man/CalculateClusterEnrichmentPairwise.Rd
@@ -55,9 +55,10 @@ A function that calculates the enrichment of a cluster under a given treatment v
 }
 \examples{
  \dontrun{
- seuratObj$cDNA_ID <- rep(1:4, ncol(seuratObj)) # This is a dummy variable for the sake of example.
- seuratObj$Vaccine <- rep(c("Vaccine1", "Vaccine2"), each = ncol(seuratObj)/2) # This is a dummy variable for the sake of example.
- seuratObj$SubjectId <- rep(1:4, each = ncol(seuratObj)/4) # This is a dummy variable for the sake of example.
+ # Define dummy variables
+ seuratObj$cDNA_ID <- rep(1:4, ncol(seuratObj)) 
+ seuratObj$Vaccine <- rep(c("Vaccine1", "Vaccine2"), each = ncol(seuratObj)/2) 
+ seuratObj$SubjectId <- rep(1:4, each = ncol(seuratObj)/4) 
  
  seuratObj <- CalculateClusterEnrichmentPairwise(seuratObj,
                                                  subjectField = 'SubjectId',
@@ -68,7 +69,9 @@ A function that calculates the enrichment of a cluster under a given treatment v
                                                  pValueCutoff = 0.05,
                                                  showPlots = TRUE, 
                                                  returnSeuratObjectOrPlots = "SeuratObject", 
-                                                 includeDepletions = FALSE)
+                                                 includeDepletions = FALSE, 
+                                                 lowSampleSizeDetection = TRUE, 
+                                                 lowSampleSizeThreshold = 3)
   DimPlot(seuratObj, group.by = "Cluster_Enrichment", label = TRUE) + NoLegend()
   }
  


### PR DESCRIPTION
Hi all, 

Small feature enhancement/bugfix from #295. The robust standard errors aren't going to be calculable for extreme cases of cluster enrichment, but those are more of a 'report for due diligence' type of measure, rather than mission critical for these functions. Currently the functions fail if this happens, and the wrapper's robustness matters more than a model's error robustness.

This PR handles edge cases where the robust standard errors fail. If one cares about discriminating robust standard errors vs standard errors in those edge cases, we should be using a Bayesian methodology instead of this wrapper. 

Best regards, 
GW